### PR TITLE
Added config option to strip domain from urls

### DIFF
--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -50,6 +50,7 @@ class ConfigLoader:
     user_agent = 'Algolia DocSearch Crawler'
     only_content_level = False
     query_rules = []
+    strip_domains = False
 
     # data storage, starting here attribute are not config params
     config_file = None

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -188,6 +188,10 @@ class DefaultStrategy(AbstractStrategy):
                     record['url_without_variables'] = url_without_variables
                     record[attr] = value
 
+                if self.config.strip_domains:
+                    record['url'] = self._get_url_without_domain(record['url'])
+                    record['url_without_variables'] = self._get_url_without_domain(record['url_without_variables'])
+
                 record['url_without_anchor'] = record['url'].split('?id=')[0]
                 record['url'] = self._get_url_with_anchor(record['url_without_anchor'],
                                                           record['anchor'])
@@ -350,3 +354,6 @@ class DefaultStrategy(AbstractStrategy):
             return current_page_url + '?id=' + anchor
 
         return current_page_url
+
+    def _get_url_without_domain(self, url):
+        return '/' + url.split('/', 3)[-1]


### PR DESCRIPTION
Added config option to strip domain from urls so that search results open correctly for localhost, staging, etc

Setting `strip_domains: true` in the config would cause https://home.applied.co/manual/simian/v1.18/#/resources_references/simian_query_api_documentation/query_schema?id=batchrequest to be indexed as /manual/simian/v1.18/#/resources_references/simian_query_api_documentation/query_schema?id=batchrequest.